### PR TITLE
수정: 스킬 아이콘 호버&터치 이벤트 동작 수정

### DIFF
--- a/src/components/Character/Passive/Passive.js
+++ b/src/components/Character/Passive/Passive.js
@@ -4,6 +4,18 @@ import SkillEffect from "components/SkillEffect/SkillEffect";
 
 function Passive({caption, passive}) {
   const [isHover, setIsHover] = useState(false);
+  const [isPreventHover, setIsPreventHover] = useState(false); // 모바일 mouseover 이벤트 막기
+
+  const mouseOverSkillIcon = () => {
+    if (!isPreventHover) {
+      setIsHover(true);
+    }
+  }
+
+  const touchSkillIcon = () => {
+    setIsHover(!isHover);
+    isHover? setIsPreventHover(true) : setIsPreventHover(false);
+  }
 
   return(
       <S.Table>
@@ -11,7 +23,10 @@ function Passive({caption, passive}) {
         <tbody>
         <tr>
           <td>
-            <S.PassivesWrap onMouseOver={() => setIsHover(true)} onMouseOut={() => setIsHover(false)}>
+            <S.PassivesWrap
+                onMouseOver={mouseOverSkillIcon}
+                onMouseOut={() => setIsHover(false)}
+                onTouchEnd={touchSkillIcon}>
               <S.Icon><img src={`${process.env.PUBLIC_URL}/images/icons/${passive.affinity}.webp`} /></S.Icon>
               <S.PassiveText>x{passive.count}</S.PassiveText>
               <S.PassiveText>{passive.name}</S.PassiveText>

--- a/src/components/Character/Passive/Passive.js
+++ b/src/components/Character/Passive/Passive.js
@@ -18,8 +18,12 @@ function Passive({caption, passive}) {
             </S.PassivesWrap>
           </td>
         </tr>
+        <tr>
+          <td>
+            {isHover? <SkillEffect effect={passive.desc} support/> : null}
+          </td>
+        </tr>
         </tbody>
-        {isHover? <SkillEffect effect={passive.desc} support/> : null}
       </S.Table>
   )
 }

--- a/src/components/Skill/Skill.js
+++ b/src/components/Skill/Skill.js
@@ -15,15 +15,31 @@ function Skill({skill}) {
   }
 
   const [isHover, setIsHover] = useState(false);
+  const [isPreventHover, setIsPreventHover] = useState(false); // 모바일 mouseover 이벤트 막기
   const [hasEffect, setHasEffect] = useState(false);
 
   useEffect(() => {
     if (skill.desc) setHasEffect(() => true);
   }, [])
 
+  const mouseOverSkillIcon = () => {
+    if (!isPreventHover) {
+      setIsHover(true);
+    }
+  }
+
+  const touchSkillIcon = (e) => {
+    setIsHover(!isHover);
+    isHover? setIsPreventHover(true) : setIsPreventHover(false);
+  }
+
   return (
       <div>
-        <S.SkillContainer onMouseOver={() => setIsHover(true)} onMouseOut={() => setIsHover(false)} hover={hasEffect}>
+        <S.SkillContainer
+            onMouseOver={mouseOverSkillIcon}
+            onMouseOut={() => setIsHover(false)}
+            onTouchEnd={(e) => touchSkillIcon(e)}
+            hover={hasEffect && isHover}>
           <S.CoinPowerText color={colorTable[skill.affinity][0]}>{skill.power.coin}</S.CoinPowerText>
           <S.SkillFrame color={colorTable[skill.affinity][1]}>
             <S.SkillFrame width={"51px"} height={"48px"}>
@@ -48,7 +64,7 @@ function Skill({skill}) {
                 <S.CoinIcon key={idx}><img src={`${process.env.PUBLIC_URL}/images/icons/coin.webp`} alt="스킬 보유 코인"/></S.CoinIcon>
             ))}
           </S.CoinsWrap>
-          {isHover? <SkillEffect effect={skill.desc} /> : null}
+          {isHover ? <SkillEffect effect={skill.desc} /> : null}
         </S.SkillContainer>
       </div>
   );

--- a/src/components/Skill/Skill.js
+++ b/src/components/Skill/Skill.js
@@ -22,34 +22,35 @@ function Skill({skill}) {
   }, [])
 
   return (
-      <S.SkillContainer onMouseOver={() => setIsHover(true)} onMouseOut={() => setIsHover(false)} hover={hasEffect}>
-        <S.CoinPowerText color={colorTable[skill.affinity][0]}>{skill.power.coin}</S.CoinPowerText>
-        <S.SkillFrame color={colorTable[skill.affinity][1]}>
-          <S.SkillFrame width={"51px"} height={"48px"}>
-            <S.SkillFrame width={"48px"} height={"46px"} color={colorTable[skill.affinity][0]}>
-              <S.SkillFrame width={"44px"} height={"42px"}>
-               <S.SkillFrame width={"40px"} height={"38px"} color={colorTable[skill.affinity][0]}>
-                 <S.SkillFrame width={"38px"} height={"36px"}>
-                    <S.SkillPowerText>{skill.power.skill}</S.SkillPowerText>
+      <div>
+        <S.SkillContainer onMouseOver={() => setIsHover(true)} onMouseOut={() => setIsHover(false)} hover={hasEffect}>
+          <S.CoinPowerText color={colorTable[skill.affinity][0]}>{skill.power.coin}</S.CoinPowerText>
+          <S.SkillFrame color={colorTable[skill.affinity][1]}>
+            <S.SkillFrame width={"51px"} height={"48px"}>
+              <S.SkillFrame width={"48px"} height={"46px"} color={colorTable[skill.affinity][0]}>
+                <S.SkillFrame width={"44px"} height={"42px"}>
+                  <S.SkillFrame width={"40px"} height={"38px"} color={colorTable[skill.affinity][0]}>
+                    <S.SkillFrame width={"38px"} height={"36px"}>
+                      <S.SkillPowerText>{skill.power.skill}</S.SkillPowerText>
+                    </S.SkillFrame>
                   </S.SkillFrame>
                 </S.SkillFrame>
               </S.SkillFrame>
             </S.SkillFrame>
           </S.SkillFrame>
-        </S.SkillFrame>
-        <S.IconsWrap>
-          <S.Icon><img src={`${process.env.PUBLIC_URL}/images/icons/${skill.type}.webp`} alt={skill.type}/></S.Icon >
-          {skill.affinity === '-' ? null : <S.Icon><img src={`${process.env.PUBLIC_URL}/images/icons/${skill.affinity}.webp`} alt={skill.affinity}/></S.Icon>}
-        </S.IconsWrap>
-        <S.NameText color={colorTable[skill.affinity][0]}>{skill.name}</S.NameText>
-        <S.CoinsWrap>
-          {[...Array(parseInt(skill.power.count))].map((n, idx) => (
-              <S.CoinIcon key={idx}><img src={`${process.env.PUBLIC_URL}/images/icons/coin.webp`} alt="스킬 보유 코인"/></S.CoinIcon>
-          ))}
-        </S.CoinsWrap>
-        {isHover? <SkillEffect effect={skill.desc} /> : null}
-      </S.SkillContainer>
-
+          <S.IconsWrap>
+            <S.Icon><img src={`${process.env.PUBLIC_URL}/images/icons/${skill.type}.webp`} alt={skill.type}/></S.Icon >
+            {skill.affinity === '-' ? null : <S.Icon><img src={`${process.env.PUBLIC_URL}/images/icons/${skill.affinity}.webp`} alt={skill.affinity}/></S.Icon>}
+          </S.IconsWrap>
+          <S.NameText color={colorTable[skill.affinity][0]}>{skill.name}</S.NameText>
+          <S.CoinsWrap>
+            {[...Array(parseInt(skill.power.count))].map((n, idx) => (
+                <S.CoinIcon key={idx}><img src={`${process.env.PUBLIC_URL}/images/icons/coin.webp`} alt="스킬 보유 코인"/></S.CoinIcon>
+            ))}
+          </S.CoinsWrap>
+          {isHover? <SkillEffect effect={skill.desc} /> : null}
+        </S.SkillContainer>
+      </div>
   );
 }
 

--- a/src/components/Skill/Skill.js
+++ b/src/components/Skill/Skill.js
@@ -64,8 +64,8 @@ function Skill({skill}) {
                 <S.CoinIcon key={idx}><img src={`${process.env.PUBLIC_URL}/images/icons/coin.webp`} alt="스킬 보유 코인"/></S.CoinIcon>
             ))}
           </S.CoinsWrap>
-          {isHover ? <SkillEffect effect={skill.desc} /> : null}
         </S.SkillContainer>
+        {isHover ? <SkillEffect effect={skill.desc} /> : null}
       </div>
   );
 }

--- a/src/components/Skill/Skill.js
+++ b/src/components/Skill/Skill.js
@@ -28,7 +28,7 @@ function Skill({skill}) {
     }
   }
 
-  const touchSkillIcon = (e) => {
+  const touchSkillIcon = () => {
     setIsHover(!isHover);
     isHover? setIsPreventHover(true) : setIsPreventHover(false);
   }
@@ -38,7 +38,7 @@ function Skill({skill}) {
         <S.SkillContainer
             onMouseOver={mouseOverSkillIcon}
             onMouseOut={() => setIsHover(false)}
-            onTouchEnd={(e) => touchSkillIcon(e)}
+            onTouchEnd={touchSkillIcon}
             hover={hasEffect && isHover}>
           <S.CoinPowerText color={colorTable[skill.affinity][0]}>{skill.power.coin}</S.CoinPowerText>
           <S.SkillFrame color={colorTable[skill.affinity][1]}>


### PR DESCRIPTION
* 스킬 박스까지 이벤트 영역으로 포함하고 있어서, 커서가 스킬 아이콘을 벗어나도 스킬 박스가 표시됨
  * 수정 전
![countAnimation1](https://user-images.githubusercontent.com/39542903/227443600-9ca828e7-e608-46c2-b7ee-614857bb850f.gif)

  * 수정 후
![countAnimation2](https://user-images.githubusercontent.com/39542903/227445351-827ff958-36ca-450b-b5c0-88bb0f3db512.gif)

---

* 모바일 환경에서 아이콘 다시 터치하거나 외부 영역 터치하면 스킬 박스 사라지도록 수정
  * 수정 전
![countAnimation3](https://user-images.githubusercontent.com/39542903/227445361-8c76c53f-88a6-46a7-80ea-d2bd45c19c45.gif)

  * 수정 후
![countAnimation4](https://user-images.githubusercontent.com/39542903/227445380-fe365453-69c5-4cae-9241-eafcf11cbd6a.gif)
